### PR TITLE
Add support for older versions of Python

### DIFF
--- a/scripts/generate_secret.py
+++ b/scripts/generate_secret.py
@@ -1,6 +1,6 @@
 
 import rstr
 
-print(f"AWS_KEYID: {rstr.xeger(r'AKIA[A-Z2-7]{16}')}")
-print(f"AWS_SECRET: {rstr.xeger(r'[0-9A-Za-z/+=]{40}')}")
-print(f"DATADOG_TOKEN: {rstr.xeger(r'[a-f0-9]{32}|[a-f0-9]{40}')}")
+print('AWS_KEYID:', rstr.xeger(r'AKIA[A-Z2-7]{16}'))
+print('AWS_SECRET:', rstr.xeger(r'[0-9A-Za-z/+=]{40}'))
+print('DATADOG_TOKEN:', rstr.xeger(r'[a-f0-9]{32}|[a-f0-9]{40}'))


### PR DESCRIPTION
It seems like the limiting factor is the use of f-strings, which, while nice, are not really required in this instance. Especially, since `print` will output arguments with a ` ` (space) by default.